### PR TITLE
(#2) Fix not existing flag

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -123,7 +123,7 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-VC_OPT="$VC_OPT -httptest.serve $VC_httptest"
+VC_OPT="$VC_OPT -l $VC_httptest"
 
 #
 # build command 


### PR DESCRIPTION
## What does this PR do?
It replaces the removed `httptest.serve` flag in favour of `l`

## Why is it important?
That flag caused vsphere was not able to even start

## Related issues
Relates https://github.com/vmware/govmomi/pull/1439/
Closes #2 